### PR TITLE
Removed acronym casing rule, relaxed uppercase const rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -3315,78 +3315,15 @@ Other Style Guides
     export default AirbnbStyleGuide;
     ```
 
-  <a name="naming--Acronyms-and-Initialisms"></a>
-  - [23.9](#naming--Acronyms-and-Initialisms) Acronyms and initialisms should always be all uppercased, or all lowercased.
-
-    > Why? Names are for readability, not to appease a computer algorithm.
-
-    ```javascript
-    // bad
-    import SmsContainer from './containers/SmsContainer';
-
-    // bad
-    const HttpRequests = [
-      // ...
-    ];
-
-    // good
-    import SMSContainer from './containers/SMSContainer';
-
-    // good
-    const HTTPRequests = [
-      // ...
-    ];
-
-    // also good
-    const httpRequests = [
-      // ...
-    ];
-
-    // best
-    import TextMessageContainer from './containers/TextMessageContainer';
-
-    // best
-    const requests = [
-      // ...
-    ];
-    ```
-
   <a name="naming--uppercase"></a>
-  - [23.10](#naming--uppercase) You may optionally uppercase a constant only if it (1) is exported, (2) is a `const` (it can not be reassigned), and (3) the programmer can trust it (and its nested properties) to never change.
-
-    > Why? This is an additional tool to assist in situations where the programmer would be unsure if a variable might ever change. UPPERCASE_VARIABLES are letting the programmer know that they can trust the variable (and its properties) not to change.
-    - What about all `const` variables? - This is unnecessary, so uppercasing should not be used for constants within a file. It should be used for exported constants however.
-    - What about exported objects? - Uppercase at the top level of export (e.g. `EXPORTED_OBJECT.key`) and maintain that all nested properties do not change.
+  - [23.9](#naming--uppercase) You may optionally uppercase constants.
 
     ```javascript
-    // bad
-    const PRIVATE_VARIABLE = 'should not be unnecessarily uppercased within a file';
-
-    // bad
-    export const THING_TO_BE_CHANGED = 'should obviously not be uppercased';
-
     // bad
     export let REASSIGNABLE_VARIABLE = 'do not use let with uppercase variables';
 
-    // ---
-
-    // allowed but does not supply semantic value
-    export const apiKey = 'SOMEKEY';
-
-    // better in most cases
-    export const API_KEY = 'SOMEKEY';
-
-    // ---
-
-    // bad - unnecessarily uppercases key while adding no semantic value
-    export const MAPPING = {
-      KEY: 'value'
-    };
-
     // good
-    export const MAPPING = {
-      key: 'value'
-    };
+    export const DEFAULT_LANG = 'et';
     ```
 
 ## Accessors


### PR DESCRIPTION
Closes #12 

As we discussed, readability is subjective and Vlad recommended removing this rule, which I agree with.

I also noticed that the next rule seemed too restrictive about naming uppercase constants, so I relaxed the criteria.