### PR TITLE
Removed rule that prevents importing with JS file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,23 +1391,6 @@ Other Style Guides
     import barCss from 'bar.css';
     ```
 
-  <a name="modules--import-extensions"></a>
-  - [10.10](#modules--import-extensions) Do not include JavaScript filename extensions
- eslint: [`import/extensions`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md)
-    > Why? Including extensions inhibits refactoring, and inappropriately hardcodes implementation details of the module you're importing in every consumer.
-
-    ```javascript
-    // bad
-    import foo from './foo.js';
-    import bar from './bar.jsx';
-    import baz from './baz/index.jsx';
-
-    // good
-    import foo from './foo';
-    import bar from './bar';
-    import baz from './baz';
-    ```
-
 ## Iterators and Generators
 
   <a name="iterators--nope"></a><a name="11.1"></a>


### PR DESCRIPTION
In ESM code (vs CommonJS), file extensions are [necessary in imports](https://nodejs.org/api/esm.html#mandatory-file-extensions).
We have used them in DaaS and BuildingBrief.
We will likely have more ESM projects in the future, so it might be time to drop this rule.